### PR TITLE
Clean up

### DIFF
--- a/input/fsh/instances/observation-partial-date-time.fsh
+++ b/input/fsh/instances/observation-partial-date-time.fsh
@@ -2,7 +2,7 @@ Instance: observation-partial-date-time-example
 InstanceOf: Observation
 Title: "Observation - Partial Date Time Extension example"
 Usage: #example
-Description: "Example of an Observation with the Partial Date Time Extension"
+Description: "Example of an Observation with Partial Date Time"
 * subject.display = "A subject"
 * effectiveDateTime = "2020-11-12T16:39:40-05:00"
 * performer.display = "A Performer"

--- a/input/fsh/instances/observation-partial-date-time.fsh
+++ b/input/fsh/instances/observation-partial-date-time.fsh
@@ -1,7 +1,8 @@
-Instance: ObservationPartialDateTimeExample
+Instance: observation-partial-date-time-example
 InstanceOf: Observation
+Title: "Observation - Partial Date Time Extension example"
 Usage: #example
-Description: "Observation with Partial Date Time"
+Description: "Example of an Observation with the Partial Date Time Extension"
 * subject.display = "A subject"
 * effectiveDateTime = "2020-11-12T16:39:40-05:00"
 * performer.display = "A Performer"

--- a/input/fsh/instances/patient-child-babyg-quinn.fsh
+++ b/input/fsh/instances/patient-child-babyg-quinn.fsh
@@ -1,7 +1,7 @@
 Instance: patient-child-vr-babyg-quinn-common
 InstanceOf: PatientChildVitalRecords
 Title: "Patient - Child example [Baby G Quinn]"
-Description: "Example of Patient-child-vr profile (Baby G Quinn)"
+Description: "Example of Patient-child-vr profile (Baby G Quinn) with Reported Parent Age at Delivery"
 Usage: #example
 * extension[race]
   * extension[ombCategory]

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -212,6 +212,7 @@ groups:
       - ExtensionPartialDateVitalRecords
       - ExtensionPostDirectionalVitalRecords
       - ExtensionPreDirectionalVitalRecords
+      - ExtensionReportedParentAgeAtDeliveryVitalRecords
       - ExtensionStreetDesignatorVitalRecords
       - ExtensionStreetNameVitalRecords
       - ExtensionStreetNumberVitalRecords
@@ -299,6 +300,7 @@ groups:
       - observation-education-level-vr-a-freeman
       - observation-emerging-issues-vr-a-freeman
       - observation-parent-education-level-vr-carmen-teresa-lee
+      - observation-partial-date-time-example
       - patient-child-vr-babyg-quinn-common
       - patient-child-vr-babyg-quinn-w-edit
       - patient-decedent-fetus-vr-not-named-common


### PR DESCRIPTION
- added reportedParentsAgeAtDelivery extension and partial datetime example to sushi config
- tweaks to example descriptions and naming convention to make them more consistent