### PR TITLE
ExtensionReportedParentAgeAtDeliveryVitalRecords: switch out discrimination of parent by references to much simpler model

### DIFF
--- a/input/fsh/extensions/ExtensionReportedParentAgeAtDeliveryVitalRecords.fsh
+++ b/input/fsh/extensions/ExtensionReportedParentAgeAtDeliveryVitalRecords.fsh
@@ -1,38 +1,33 @@
 Extension: ExtensionReportedParentAgeAtDeliveryVitalRecords
 Id: Extension-reported-parent-age-at-delivery-vr
 Title: "Extension - Reported Parent Age At Delivery - Vital Records"
-Description: "This Extension profile represents the reported age of the parent (either the gestational mother or the natural father - as defined by NCHS) at the delivery time of the newborn or fetus. A reference to either the **Patient - Mother - Vital Records** or the **RelatedPerson - Father Natural - Vital Records** represents the parent. It can optionally contain a reference to the reporter (**US Core Patient Profile** or **US Core RelatedPerson Profile**)."
+Description: "This Extension profile represents the reported age of the parent (either the gestational mother or the natural father - as defined by NCHS) at the delivery time of the newborn or fetus. 
+A required code indicates whether the mother or father's age is provided. It can optionally contain a reference to the reporter (**US Core Patient Profile** or **US Core RelatedPerson Profile**)."
 * ^experimental = false
 * ^context.type = #element
 * ^context.expression = "Patient"
 * . 0..*
   * ^short = "Extension - Reported Parent Age at Delivery - Vital Records"
-  * ^definition = "This Extension profile represents the reported age of the parent at the delivery time of the newborn or fetus. It also contains a reference to the newborn (Patient - Child - Vital Records) or the fetus (Patient - Decedent Fetus - Vital Records) in which is located the date of delivery (Patient.birthDate). It can optionally contain a reference to the reporter (US Core Patient Profile or US Core RelatedPerson Profile)."
+  * ^definition = "This Extension profile represents the reported age of the parent at the delivery time of the newborn or fetus. 
+  A required code indicates whether the mother or father's age is provided. 
+  It can optionally contain a reference to the reporter (US Core Patient Profile or US Core RelatedPerson Profile)."
 * extension ..3
   * ^slicing.discriminator.type = #value
   * ^slicing.discriminator.path = "url"
   * ^slicing.rules = #open
 * extension contains
     reportedAge 1..1 MS and
-    motherOrFather 1..1 MS and
+    ExtensionRoleVitalRecords named motherOrFather 1..1 MS and
     reporter 0..1
 * extension[reportedAge] only Extension
   * ^short = "Age of the parent at the time of delivery reported by another person."
   * ^definition = "Age of the parent at the time of delivery reported by another person."
-  * url only uri
   * value[x] 1..1
   * value[x] only Quantity
     * ^short = "Reported age in years"
-* extension[motherOrFather] only Extension
-  * ^short = "Reference to the mother or father."
-  * ^definition = "Reference to the mother or father."
-  * url only uri
-  * value[x] 1..1
-  * value[x] only Reference(PatientMotherVitalRecords or RelatedPersonFatherNaturalVitalRecords)
-    * ^short = "Reported age in years"
+* extension[motherOrFather] ^short = "Mother or Father"
 * extension[reporter] only Extension
   * ^short = "Reference to the person who reported the parent's age."
   * ^definition = "Reference to the person who reported the parent's age."
-  * url only uri
   * value[x] 1..1
   * value[x] only Reference(USCorePatientProfile or USCoreRelatedPersonProfile)

--- a/input/fsh/instances/patient-child-babyg-quinn-w-edit.fsh
+++ b/input/fsh/instances/patient-child-babyg-quinn-w-edit.fsh
@@ -20,6 +20,11 @@ Usage: #example
     * city = "Salt Lake City"
     * district = "Salt Lake"
     * state = "UT"
+* extension[parentReportedAgeAtDelivery]
+  * extension[reportedAge]
+    * valueQuantity = 34 'a'
+  * extension[motherOrFather]
+    * valueCodeableConcept = $v3-RoleCode#MTH "mother"
 * identifier
   * use = #usual
   * type = $v2-0203#MR "Medical Record Number"

--- a/input/fsh/instances/patient-child-babyg-quinn.fsh
+++ b/input/fsh/instances/patient-child-babyg-quinn.fsh
@@ -24,7 +24,7 @@ Usage: #example
   * extension[reportedAge]
     * valueQuantity = 34 'a'
   * extension[motherOrFather]
-    * valueReference = Reference(patient-mother-vr-jada-ann-quinn-common)
+    * valueCodeableConcept = $v3-RoleCode#MTH "mother"
 * identifier
   * use = #usual
   * type = $v2-0203#MR "Medical Record Number"


### PR DESCRIPTION
ExtensionReportedParentAgeAtDeliveryVitalRecords had a very complex discriminator
Updates needed to data dictionaries in BFDR.
Extensions for both parents should be added to BabyQuinn and DecedentFetus example(s) in BFDR.
