### PR TITLE
Fix patient name cardinalities

### DIFF
--- a/input/fsh/harmonized-profiles/PatientVitalRecords_new.fsh
+++ b/input/fsh/harmonized-profiles/PatientVitalRecords_new.fsh
@@ -49,8 +49,8 @@ Description: "This abstract Patient profile includes common extensions and slici
   * use = #maiden (exactly)
   * ^short = "Name prior to first marriage"
 * name 
-  * use 1..1 
-  * family 1..
+//  * use 1..1 
+  * family // 1..
     * extension ^slicing.discriminator.type = #value
       * ^slicing.discriminator.path = "url"
       * ^slicing.rules = #open

--- a/input/pagecontent/usage.md
+++ b/input/pagecontent/usage.md
@@ -1,3 +1,6 @@
+### Local Time
+All event times should be recorded as the local time and local time zone where they took place.
+
 ### Partial Dates and Times
 The purpose of the these extensions ([ExtensionPartialDateVitalRecords] and [ExtensionPartialDateTimeVitalRecords]) is to be able to express [date](https://hl7.org/fhir/R4B/datatypes.html#date) and [datetime](https://hl7.org/fhir/R4B/datatypes.html#datetime) values when some components are not known.  For some fields reported in vital records, all four components (year, month, day, time) can be reported/absent independently, resulting in combinations that are not supported by a FHIR dateTime (YYYY, YYYY-MM, YYYY-MM-DD, or a full dateTime).  The additional combinations supported by these extensions include:
 


### PR DESCRIPTION
Michael from GTRI pointed out that the PatientVitalRecords profile added new constraints to USCorePatients.
I relaxed these unnecessary constraints.