### PR TITLE
update gender url

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -46,7 +46,7 @@ Alias: $IJE = CodeSystemIJEVitalRecords
 
 // External CS and VS
 Alias: $v2-0532 = http://terminology.hl7.org/CodeSystem/v2-0532
-Alias: $admingender = http://hl7.org/fhir/administrative-gender
+Alias: $admingender = https://terminology.hl7.org/5.4.0/CodeSystem-v3-AdministrativeGender.html
 Alias: $maritalStatus = http://hl7.org/fhir/ValueSet/marital-status
 Alias: $roleCode = http://terminology.hl7.org/CodeSystem/v3-RoleCode
 Alias: $contactRole = http://terminology.hl7.org/CodeSystem/v2-0131

--- a/input/fsh/conceptmaps/CM_BirthSexChild.fsh
+++ b/input/fsh/conceptmaps/CM_BirthSexChild.fsh
@@ -4,7 +4,7 @@ Title: "Birth Sex Child Vital Records"
 Usage: #definition
 * experimental = false
 * insert ConceptMapIntro(BirthSex, ValueSetSexAssignedAtBirthVitalRecords)
-* insert AddGroup( $IJE, $v3-AdministrativeGender)
+* insert AddGroup( $IJE, $admingender)
 * insert MapConcept( #M,  "Male", #M, "Male")
 * insert MapConcept( #F,  "Female", #F, "Female")
 * insert AddGroup( $IJE, $v3-NullFlavor)

--- a/input/fsh/conceptmaps/CM_BirthSexFetus.fsh
+++ b/input/fsh/conceptmaps/CM_BirthSexFetus.fsh
@@ -4,7 +4,7 @@ Title: "Birth Sex Fetus Vital Records"
 Usage: #definition
 * experimental = false
 * insert ConceptMapIntro(BirthSex, ValueSetSexAssignedAtBirthVitalRecords)
-* insert AddGroup($IJE,$v3-AdministrativeGender)
+* insert AddGroup($IJE,$admingender)
 * insert MapConcept( #M,  "Male", #M, "Male")
 * insert MapConcept( #F,  "Female", #F, "Female")
 * insert AddGroup($IJE,$v3-NullFlavor)


### PR DESCRIPTION
VRCL was using a different CS for administrative gender than VRDR. They should both be able to use the one in VRDR (M,F,U)