### PR TITLE
narrative tweaks to terminology desc

### DIFF
--- a/input/fsh/codesystems/CodeSystemCanadianProvincesVitalRecords.fsh
+++ b/input/fsh/codesystems/CodeSystemCanadianProvincesVitalRecords.fsh
@@ -36,7 +36,8 @@
 CodeSystem: CodeSystemUSStatesTerritoriesVitalRecords
 Id: CodeSystem-us-states-territories-vr 
 Title: "US States and Territories"
-Description: "Surrogate for usps.com codesystem.  IG Publisher is not happy with that codesystem."
+Description: "Surrogate for usps.com codesystem - IG Publisher found issues with that codesystem.
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 * ^caseSensitive = true
 * ^experimental = false
 * #AL  "Alabama" "Alabama"

--- a/input/fsh/codesystems/CodeSystemComponent.fsh
+++ b/input/fsh/codesystems/CodeSystemComponent.fsh
@@ -4,7 +4,8 @@ RuleSet: PlaceComponentCode(len, number)
 CodeSystem: CodeSystemComponentVitalRecords
 Id: codesystem-vr-component
 Title: "Local Component Codes"
-Description: "Local Component Codes for observation components that lack an appropriate LOINC code"
+Description: "Local Component Codes for observation components that lack an appropriate LOINC code.
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 * insert boilerplate
 * ^content = #complete
 * ^caseSensitive = false

--- a/input/fsh/codesystems/CodeSystemCountryVitalRecords.fsh
+++ b/input/fsh/codesystems/CodeSystemCountryVitalRecords.fsh
@@ -1,7 +1,8 @@
 CodeSystem: CodeSystemCountryCodeVitalRecords
 Id: CodeSystem-country-code-vr
 Title: "Country Codes Vital Records"
-Description: "2 Letter Country Codes from GEC and ISO 3166-1"
+Description: "2 Letter Country Codes from GEC and ISO 3166-1.
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 * ^caseSensitive = false
 * #AA "Aruba" "Aruba"
 * #AC "Antigua And Barbuda" "Antigua And Barbuda"

--- a/input/fsh/codesystems/CodeSystemEditFlags.fsh
+++ b/input/fsh/codesystems/CodeSystemEditFlags.fsh
@@ -1,7 +1,8 @@
 CodeSystem: CodeSystemEditFlagsVitalRecords
 Id: CodeSystem-vr-edit-flags
 Title: "Birth and Death Edit Flags Vital Records"
-Description: "This code system contains codes to represent all edit flags"
+Description: "This code system contains codes to represent all edit flags.
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 * ^caseSensitive = true
 * ^content = #complete
 * ^experimental = false

--- a/input/fsh/codesystems/CodeSystemHispanicOriginVitalRecords.fsh
+++ b/input/fsh/codesystems/CodeSystemHispanicOriginVitalRecords.fsh
@@ -1,7 +1,8 @@
 CodeSystem: CodeSystemHispanicOriginVitalRecords
 Id: CodeSystem-hispanic-origin-vr
 Title: "HispanicOrigin Vital Records"
-Description: "HispanicOrigin from [Appendix_D_Excel_Hispanic_Origin_Code_List_Update_2011](https://www.cdc.gov/nchs/data/dvs/Appendix_D_Excel_Hispanic_Origin_Code_List_Update_2011.xls)"
+Description: "HispanicOrigin from [Appendix_D_Excel_Hispanic_Origin_Code_List_Update_2011](https://www.cdc.gov/nchs/data/dvs/Appendix_D_Excel_Hispanic_Origin_Code_List_Update_2011.xls).
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 
 * ^caseSensitive = true
 * ^experimental = false

--- a/input/fsh/codesystems/CodeSystemIJE.fsh
+++ b/input/fsh/codesystems/CodeSystemIJE.fsh
@@ -1,7 +1,8 @@
 CodeSystem: CodeSystemIJEVitalRecords
 Id: codesystem-ije-vr
 Title: "Placeholder Code System for IJE in Vital Records"
-Description: "IJE Code System Placeholder is needed to provide a URL upon which to anchor concept maps."
+Description: "IJE Code System Placeholder is needed to provide a URL upon which to anchor concept maps.
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 * ^caseSensitive = false
 * ^compositional = false
 * ^versionNeeded = false

--- a/input/fsh/codesystems/CodeSystemJurisdictionsVitalRecords.fsh
+++ b/input/fsh/codesystems/CodeSystemJurisdictionsVitalRecords.fsh
@@ -2,7 +2,8 @@
 CodeSystem: CodeSystemJurisdictionsVitalRecords
 Id: CodeSystem-jurisdictions-vr
 Title: "Jurisdictions Vital Records"
-Description: "NVSS Jurisdictions that are not US States or Territories"
+Description: "NVSS Jurisdictions that are not US States or Territories.
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 * ^caseSensitive = true
 * #YC "New York City" "New York City"
 * ^experimental = false

--- a/input/fsh/codesystems/CodeSystemLocalObservationCodesVitalRecords.fsh
+++ b/input/fsh/codesystems/CodeSystemLocalObservationCodesVitalRecords.fsh
@@ -1,7 +1,8 @@
 CodeSystem: CodeSystemLocalObservationsCodesVitalRecords
 Id: CodeSystem-local-observation-codes-vr
 Title: "Local Observation Codes Vital Records"
-Description: "Local Observation Codes for observations that lack an appropriate LOINC code"
+Description: "Local Observation Codes for observations that lack an appropriate LOINC code.
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 * insert boilerplate
 * ^content = #complete
 * ^caseSensitive = false

--- a/input/fsh/codesystems/CodeSystemRaceCodeVitalRecords.fsh
+++ b/input/fsh/codesystems/CodeSystemRaceCodeVitalRecords.fsh
@@ -1,7 +1,8 @@
 CodeSystem: CodeSystemRaceCodeVitalRecords
 Id: CodeSystem-race-code-vr
 Title: "Race Code Vital Records"
-Description: "RaceCode from [Appendix E Excel Race Code List Update 2001](https://www.cdc.gov/nchs/data/dvs/Appendix_E_Excel_Race_Code_List_Update_2011.xls)"
+Description: "RaceCode from [Appendix E Excel Race Code List Update 2001](https://www.cdc.gov/nchs/data/dvs/Appendix_E_Excel_Race_Code_List_Update_2011.xls).
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 * ^caseSensitive = true
 * ^experimental = false
 * #100 "White Checkbox"

--- a/input/fsh/codesystems/CodeSystemRaceRecode40VitalRecords.fsh
+++ b/input/fsh/codesystems/CodeSystemRaceRecode40VitalRecords.fsh
@@ -1,7 +1,8 @@
 CodeSystem: CodeSystemRaceRecode40VitalRecords
 Id: CodeSystem-race-recode-40-vr
 Title: "Race Recode 40 Vital Records"
-Description: "Race Recode 40"
+Description: "Race Recode 40
+This codesystem is only for use in the vital records use cases supported by this Implementation guide, and should not be used elsewhere."
 * ^caseSensitive = true
 * ^experimental = false
 * #01 "White"

--- a/input/fsh/valuesets/ValueSetBirthAttendantTitles.fsh
+++ b/input/fsh/valuesets/ValueSetBirthAttendantTitles.fsh
@@ -1,7 +1,9 @@
 ValueSet: ValueSetBirthAttendantTitlesVitalRecords
 Id: ValueSet-birth-attendant-titles-vr
 Title: "Birth Attendants Titles Vital Records"
-Description: "This valueset contains codes to represent the type of birth attendant titles. This valueset is based on [PHVS_BirthAttendantTitles_NCHS](https://phinvads.cdc.gov/vads/ViewValueSet.action?id=7B108BDB-5F50-482F-9E9D-643EC75364A2)
+Description: "This valueset contains codes to represent the type of birth attendant titles. 
+It is based on the original [PHVS_BirthAttendantTitles_NCHS](https://phinvads.cdc.gov/vads/ViewValueSet.action?id=7B108BDB-5F50-482F-9E9D-643EC75364A2) PHINVADS valueset. 
+This IG is the primary source for valuesets for use in vital records.
 
 Mapping to IJE codes [here](ConceptMap-ConceptMapBirthAttendantTitlesVitalRecords.html)."
 * ^experimental = false

--- a/input/fsh/valuesets/ValueSetDateOfBirthEditFlags.fsh
+++ b/input/fsh/valuesets/ValueSetDateOfBirthEditFlags.fsh
@@ -1,7 +1,9 @@
 ValueSet: ValueSetDateOfBirthEditFlagsVitalRecords
 Id: ValueSet-date-of-birth-edit-flags-vr 
 Title: "Date of Birth Edit Flags (NCHS) Vital Records"
-Description: "This valueset contains codes to represent Date of Birth Edit Flags. This valueset is based on [PHVS_BirthdateEditFlags_NCHS](https://phinvads.cdc.gov/vads/ViewValueSet.action?id=3BD473EE-40DD-E811-816D-0017A477041A)
+Description: "This valueset contains codes to represent Date of Birth Edit Flags. 
+It is based on the original [PHVS_BirthdateEditFlags_NCHS](https://phinvads.cdc.gov/vads/ViewValueSet.action?id=3BD473EE-40DD-E811-816D-0017A477041A) PHINVADS valueset. 
+This IG is the primary source for valuesets for use in vital records.
 
 Mapping to IJE codes [here](ConceptMap-ConceptMapDateOfBirthEditFlagsVitalRecords.html)."
 * ^experimental = false

--- a/input/fsh/valuesets/ValueSetPluralityEditFlags.fsh
+++ b/input/fsh/valuesets/ValueSetPluralityEditFlags.fsh
@@ -1,7 +1,9 @@
 ValueSet: ValueSetPluralityEditFlagsVitalRecords
 Id: ValueSet-plurality-edit-flags-vr 
 Title: "Plurality Edit Flags (NCHS) Vital Records"
-Description: "This valueset contains codes to represent Plurality Edit Flags. This valueset is based on [PHVS_PluralityEditFlags_NCHS](https://phinvads.cdc.gov/vads/ViewValueSet.action?id=3A484C53-FDFD-E611-A856-0017A477041A)
+Description: "This valueset contains codes to represent Plurality Edit Flags. 
+It is based on the original [PHVS_PluralityEditFlags_NCHS](https://phinvads.cdc.gov/vads/ViewValueSet.action?id=3A484C53-FDFD-E611-A856-0017A477041A) PHINVADS valueset. 
+This IG is the primary source for valuesets for use in vital records.
 
 Mapping to IJE codes [here](ConceptMap-ConceptMapPluralityEditFlagsVitalRecords.html)."
 * ^experimental = false

--- a/input/fsh/valuesets/ValueSetYesNoNotApplicableVitalRecords.fsh
+++ b/input/fsh/valuesets/ValueSetYesNoNotApplicableVitalRecords.fsh
@@ -1,7 +1,9 @@
 ValueSet: ValueSetYesNoNotApplicableVitalRecords
 Id: ValueSet-yes-no-not-applicable-vr
 Title: "Yes No Not Applicable Vital Records"
-Description: "A set of codes used to respond to any question that can be answered Yes, No, or Not Applicable. Based on [Yes No Not Applicable (NCHS)[2.16.840.1.114222.4.11.7486]](https://phinvads.cdc.gov/vads/ViewValueSet.action?oid=2.16.840.1.114222.4.11.7486)
+Description: "A set of codes used to respond to any question that can be answered Yes, No, or Not Applicable. 
+It is based on the original [Yes No Not Applicable (NCHS)[2.16.840.1.114222.4.11.7486]](https://phinvads.cdc.gov/vads/ViewValueSet.action?oid=2.16.840.1.114222.4.11.7486) PHINVADS valueset. 
+This IG is the primary source for valuesets for use in vital records.
 
 Mapping to IJE codes [here](ConceptMap-ConceptMapYesNoNotApplicableVitalRecords.html)."
 * ^status = #active


### PR DESCRIPTION
Narrative updates to terminology to make it clear that locally defined codes are meant only for vital stats use cases and may be inspired by PHINVADS