### PR TITLE
Invariant not dead child

### DIFF
--- a/input/fsh/instances/patient-child-babyg-quinn.fsh
+++ b/input/fsh/instances/patient-child-babyg-quinn.fsh
@@ -33,6 +33,8 @@ RuleSet: babyquinncommon
   * given[1] = "G"
 * gender = #female
 * multipleBirthInteger = 1
+* deceasedBoolean = false 
+//* deceasedBoolean = true  // test that the invariant works.. It Works!
 
 Instance: patient-child-vr-babyg-quinn-common
 InstanceOf: PatientChildVitalRecords

--- a/input/fsh/profiles/PatientChildVitalRecords.fsh
+++ b/input/fsh/profiles/PatientChildVitalRecords.fsh
@@ -3,6 +3,7 @@ Parent: PatientVitalRecords
 Id: Patient-child-vr
 Title: "Patient - Child Vital Records"
 Description: "The subject patient (newborn/infant/child) for whom clinical data is included in the report."
+* obeys childNotDeceased
 * extension[race] MS
 * extension[ethnicity] MS
 * extension[birthsex] 1.. MS
@@ -49,3 +50,11 @@ RuleSet: birthDateAndTime
 
 
   // * extension[datePartAbsentReason] MS 
+Invariant: childNotDeceased
+Description: "Patients who are marked deceased don't conform to PatientChildVitalRecords. If the deceased field is present, it must be false"
+Severity: #error
+* expression = "deceased.exists() implies deceased = false"
+//     "(deceased.exists()
+//   implies
+//      (value = 'false'))"
+


### PR DESCRIPTION
Added an invariant (with the help of ChatGPT) to help differentiate PatientChild from PatientFetus.
Fetus must have deceased=true.   
Child can't have deceased=true.  It can have deceased=false.