### PR TITLE
Coded Race mapping

### DIFF
--- a/input/pagecontent/StructureDefinition-coded-race-and-ethnicity-vr-intro.md
+++ b/input/pagecontent/StructureDefinition-coded-race-and-ethnicity-vr-intro.md
@@ -788,8 +788,8 @@ Coded race and ethnicity data is communicated for both the mother and father in 
   <td>First Edited Code</td>
   <td>RACE1E</td>
   <td>component[FirstEditedCode].value, <br />code=CodeSystemLocalObservationsCodesVitalRecords#codedraceandethnicityDecedent</td>
-  <td></td>
-  <td>-</td>
+  <td>codeable</td>
+  <td><a href='ValueSet-ValueSet-race-code-vr.html'>ValueSetRaceCodeVitalRecords</a></td>
 </tr>
 <tr>
   <td style='text-align: center'>Mortality</td>


### PR DESCRIPTION
Mapping for RACE1E was missing Type and Valueset. Also updated data dictionary in VRDR

See Mortality(Decedent) mapping: https://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-coded-race-and-ethnicity-vr.html